### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,8 +31,12 @@ class ItemsController < ApplicationController
   end
 
   def update
-    item = Item.find(params[:id])
-    item.update(item_params)
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path
+    else
+      render :edit
+    end
   end
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,6 @@
 class ItemsController < ApplicationController
+before_action :set_item, only: [:show, :edit, :update]
+
   def index
     @items = Item.all.order("created_at DESC")
     @purchases = Purchase.all
@@ -22,16 +24,13 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
     @purchases = Purchase.all
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path
     else
@@ -42,5 +41,9 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:image, :name, :explanation, :category_id, :condition_id, :shipping_charge_id, :prefecture_id, :days_until_shipping_id, :price).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :edit, :update]
+  before_action :move_ragular, only: [:edit]
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -27,14 +28,6 @@ class ItemsController < ApplicationController
     @purchases = Purchase.all
   end
 
-  def edit
-    if !(user_signed_in?)
-      redirect_to new_user_session_path
-    elsif current_user.id != @item.user_id
-      redirect_to root_path
-    end
-  end
-
   def update
     if @item.update(item_params)
       redirect_to item_path
@@ -51,5 +44,13 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def move_ragular
+    if !(user_signed_in?)
+      redirect_to new_user_session_path
+    elsif current_user.id != @item.user_id
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,6 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :edit, :update]
-  before_action :move_to_session, only:[:edit]
-  before_action :move_to_root, only: [:edit]
+
   def index
     @items = Item.all.order("created_at DESC")
     @purchases = Purchase.all
@@ -29,6 +28,11 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    if !(user_signed_in?)
+      redirect_to new_user_session_path
+    elsif current_user.id != @item.user_id
+      redirect_to root_path
+    end
   end
 
   def update
@@ -47,17 +51,5 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
-  end
-
-  def move_to_session
-    unless user_signed_in?
-      redirect_to new_user_session_path
-    end
-  end
-
-  def move_to_root
-    if current_user.id != @item.user_id
-      redirect_to root_path
-    end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,6 +30,10 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def update
+    item = Item.find(params[:id])
+    item.update(item_params)
+  end
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
-before_action :set_item, only: [:show, :edit, :update]
-
+  before_action :set_item, only: [:show, :edit, :update]
+  before_action :move_to_session, only:[:edit]
+  before_action :move_to_root, only: [:edit]
   def index
     @items = Item.all.order("created_at DESC")
     @purchases = Purchase.all
@@ -37,6 +38,7 @@ before_action :set_item, only: [:show, :edit, :update]
       render :edit
     end
   end
+
   private
 
   def item_params
@@ -45,5 +47,17 @@ before_action :set_item, only: [:show, :edit, :update]
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def move_to_session
+    unless user_signed_in?
+      redirect_to new_user_session_path
+    end
+  end
+
+  def move_to_root
+    if current_user.id != @item.user_id
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,6 +26,10 @@ class ItemsController < ApplicationController
     @purchases = Purchase.all
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/views/items/_item_data.html.erb
+++ b/app/views/items/_item_data.html.erb
@@ -1,0 +1,125 @@
+<%# 出品画像 %>
+<div class="img-upload">
+  <div class="weight-bold-text">
+    出品画像
+    <span class="indispensable">必須</span>
+  </div>
+  <div class="click-upload">
+    <p>
+      クリックしてファイルをアップロード
+    </p>
+    <%= form.file_field :image, id:"item-image" %>
+  </div>
+</div>
+<%# /出品画像 %>
+<%# 商品名と商品説明 %>
+<div class="new-items">
+  <div class="weight-bold-text">
+    商品名
+    <span class="indispensable">必須</span>
+  </div>
+  <%= form.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+  <div class="items-explain">
+    <div class="weight-bold-text">
+      商品の説明
+      <span class="indispensable">必須</span>
+    </div>
+    <%= form.text_area :explanation, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+  </div>
+</div>
+<%# /商品名と商品説明 %>
+
+<%# 商品の詳細 %>
+<div class="items-detail">
+  <div class="weight-bold-text">商品の詳細</div>
+  <div class="form">
+    <div class="weight-bold-text">
+      カテゴリー
+      <span class="indispensable">必須</span>
+    </div>
+    <%= form.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+    <div class="weight-bold-text">
+      商品の状態
+      <span class="indispensable">必須</span>
+    </div>
+    <%= form.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+  </div>
+</div>
+<%# /商品の詳細 %>
+
+<%# 配送について %>
+<div class="items-detail">
+  <div class="weight-bold-text question-text">
+    <span>配送について</span>
+    <a class="question" href="#">?</a>
+  </div>
+  <div class="form">
+    <div class="weight-bold-text">
+      配送料の負担
+      <span class="indispensable">必須</span>
+    </div>
+    <%= form.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+    <div class="weight-bold-text">
+      発送元の地域
+      <span class="indispensable">必須</span>
+    </div>
+    <%= form.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+    <div class="weight-bold-text">
+      発送までの日数
+      <span class="indispensable">必須</span>
+    </div>
+    <%= form.collection_select(:days_until_shipping_id, DaysUntilShipping.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+  </div>
+</div>
+<%# /配送について %>
+
+<%# 販売価格 %>
+<div class="sell-price">
+  <div class="weight-bold-text question-text">
+    <span>販売価格<br>(¥300〜9,999,999)</span>
+    <a class="question" href="#">?</a>
+  </div>
+  <div>
+    <div class="price-content">
+      <div class="price-text">
+        <span>価格</span>
+        <span class="indispensable">必須</span>
+      </div>
+      <span class="sell-yen">¥</span>
+      <%= form.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+    </div>
+    <div class="price-content">
+      <span>販売手数料 (10%)</span>
+      <span>
+        <span id='add-tax-price'></span>円
+      </span>
+    </div>
+    <div class="price-content">
+      <span>販売利益</span>
+      <span>
+        <span id='profit'></span>円
+      </span>
+    </div>
+  </div>
+</div>
+<%# /販売価格 %>
+
+<%# 注意書き %>
+<div class="caution">
+  <p class="sentence">
+    <a href="#">禁止されている出品、</a>
+    <a href="#">行為</a>
+    を必ずご確認ください。
+  </p>
+  <p class="sentence">
+    またブランド品でシリアルナンバー等がある場合はご記載ください。
+    <a href="#">偽ブランドの販売</a>
+    は犯罪であり処罰される可能性があります。
+  </p>
+  <p class="sentence">
+    また、出品をもちまして
+    <a href="#">加盟店規約</a>
+    に同意したことになります。
+  </p>
+</div>
+<%# /注意書き %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,0 +1,161 @@
+<%# cssは商品出品のものを併用しています。
+app/assets/stylesheets/items/new.css %>
+
+<div class="items-sell-contents">
+  <header class="items-sell-header">
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+  </header>
+  <div class="items-sell-main">
+    <h2 class="items-sell-title">商品の情報を入力</h2>
+    <%= form_with local: true do |f| %>
+
+    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%# render 'shared/error_messages', model: f.object %>
+    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+
+    <%# 出品画像 %>
+    <div class="img-upload">
+      <div class="weight-bold-text">
+        出品画像
+        <span class="indispensable">必須</span>
+      </div>
+      <div class="click-upload">
+        <p>
+          クリックしてファイルをアップロード
+        </p>
+        <%= f.file_field :hoge, id:"item-image" %>
+      </div>
+    </div>
+    <%# /出品画像 %>
+    <%# 商品名と商品説明 %>
+    <div class="new-items">
+      <div class="weight-bold-text">
+        商品名
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <div class="items-explain">
+        <div class="weight-bold-text">
+          商品の説明
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+      </div>
+    </div>
+    <%# /商品名と商品説明 %>
+
+    <%# 商品の詳細 %>
+    <div class="items-detail">
+      <div class="weight-bold-text">商品の詳細</div>
+      <div class="form">
+        <div class="weight-bold-text">
+          カテゴリー
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <div class="weight-bold-text">
+          商品の状態
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+      </div>
+    </div>
+    <%# /商品の詳細 %>
+
+    <%# 配送について %>
+    <div class="items-detail">
+      <div class="weight-bold-text question-text">
+        <span>配送について</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div class="form">
+        <div class="weight-bold-text">
+          配送料の負担
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <div class="weight-bold-text">
+          発送元の地域
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <div class="weight-bold-text">
+          発送までの日数
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+      </div>
+    </div>
+    <%# /配送について %>
+
+    <%# 販売価格 %>
+    <div class="sell-price">
+      <div class="weight-bold-text question-text">
+        <span>販売価格<br>(¥300〜9,999,999)</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div>
+        <div class="price-content">
+          <div class="price-text">
+            <span>価格</span>
+            <span class="indispensable">必須</span>
+          </div>
+          <span class="sell-yen">¥</span>
+          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+        </div>
+        <div class="price-content">
+          <span>販売手数料 (10%)</span>
+          <span>
+            <span id='add-tax-price'></span>円
+          </span>
+        </div>
+        <div class="price-content">
+          <span>販売利益</span>
+          <span>
+            <span id='profit'></span>円
+          </span>
+        </div>
+      </div>
+    </div>
+    <%# /販売価格 %>
+
+    <%# 注意書き %>
+    <div class="caution">
+      <p class="sentence">
+        <a href="#">禁止されている出品、</a>
+        <a href="#">行為</a>
+        を必ずご確認ください。
+      </p>
+      <p class="sentence">
+        またブランド品でシリアルナンバー等がある場合はご記載ください。
+        <a href="#">偽ブランドの販売</a>
+        は犯罪であり処罰される可能性があります。
+      </p>
+      <p class="sentence">
+        また、出品をもちまして
+        <a href="#">加盟店規約</a>
+        に同意したことになります。
+      </p>
+    </div>
+    <%# /注意書き %>
+    <%# 下部ボタン %>
+    <div class="sell-btn-contents">
+      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', "#", class:"back-btn" %>
+    </div>
+    <%# /下部ボタン %>
+  </div>
+  <% end %>
+
+  <footer class="items-sell-footer">
+    <ul class="menu">
+      <li><a href="#">プライバシーポリシー</a></li>
+      <li><a href="#">フリマ利用規約</a></li>
+      <li><a href="#">特定商取引に関する表記</a></li>
+    </ul>
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <p class="inc">
+      ©︎Furima,Inc.
+    </p>
+  </footer>
+</div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,138 +7,14 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, local: true do |f| %>
+    <%= form_with model: @item, local: true do |form| %>
 
       <%= render 'shared/error_messages', model: @item %>
+      <%= render 'item_data', form: form %>
 
-      <%# 出品画像 %>
-      <div class="img-upload">
-        <div class="weight-bold-text">
-          出品画像
-          <span class="indispensable">必須</span>
-        </div>
-        <div class="click-upload">
-          <p>
-            クリックしてファイルをアップロード
-          </p>
-          <%= f.file_field :image, id:"item-image" %>
-        </div>
-      </div>
-      <%# /出品画像 %>
-      <%# 商品名と商品説明 %>
-      <div class="new-items">
-        <div class="weight-bold-text">
-          商品名
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
-        <div class="items-explain">
-          <div class="weight-bold-text">
-            商品の説明
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.text_area :explanation, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
-        </div>
-      </div>
-      <%# /商品名と商品説明 %>
-
-      <%# 商品の詳細 %>
-      <div class="items-detail">
-        <div class="weight-bold-text">商品の詳細</div>
-        <div class="form">
-          <div class="weight-bold-text">
-            カテゴリー
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
-          <div class="weight-bold-text">
-            商品の状態
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
-        </div>
-      </div>
-      <%# /商品の詳細 %>
-
-      <%# 配送について %>
-      <div class="items-detail">
-        <div class="weight-bold-text question-text">
-          <span>配送について</span>
-          <a class="question" href="#">?</a>
-        </div>
-        <div class="form">
-          <div class="weight-bold-text">
-            配送料の負担
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-          <div class="weight-bold-text">
-            発送元の地域
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
-          <div class="weight-bold-text">
-            発送までの日数
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.collection_select(:days_until_shipping_id, DaysUntilShipping.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-        </div>
-      </div>
-      <%# /配送について %>
-
-      <%# 販売価格 %>
-      <div class="sell-price">
-        <div class="weight-bold-text question-text">
-          <span>販売価格<br>(¥300〜9,999,999)</span>
-          <a class="question" href="#">?</a>
-        </div>
-        <div>
-          <div class="price-content">
-            <div class="price-text">
-              <span>価格</span>
-              <span class="indispensable">必須</span>
-            </div>
-            <span class="sell-yen">¥</span>
-            <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
-          </div>
-          <div class="price-content">
-            <span>販売手数料 (10%)</span>
-            <span>
-              <span id='add-tax-price'></span>円
-            </span>
-          </div>
-          <div class="price-content">
-            <span>販売利益</span>
-            <span>
-              <span id='profit'></span>円
-            </span>
-          </div>
-        </div>
-      </div>
-      <%# /販売価格 %>
-
-      <%# 注意書き %>
-      <div class="caution">
-        <p class="sentence">
-          <a href="#">禁止されている出品、</a>
-          <a href="#">行為</a>
-          を必ずご確認ください。
-        </p>
-        <p class="sentence">
-          またブランド品でシリアルナンバー等がある場合はご記載ください。
-          <a href="#">偽ブランドの販売</a>
-          は犯罪であり処罰される可能性があります。
-        </p>
-        <p class="sentence">
-          また、出品をもちまして
-          <a href="#">加盟店規約</a>
-          に同意したことになります。
-        </p>
-      </div>
-      <%# /注意書き %>
       <%# 下部ボタン %>
       <div class="sell-btn-contents">
-        <%= f.submit "変更する" ,class:"sell-btn" %>
+        <%= form.submit "変更する" ,class:"sell-btn" %>
         <%=link_to 'もどる', root_path, class:"back-btn" %>
       </div>
       <%# /下部ボタン %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, url: item_path, local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
       <%= render 'shared/error_messages', model: @item %>
 
@@ -142,7 +142,7 @@ app/assets/stylesheets/items/new.css %>
         <%=link_to 'もどる', root_path, class:"back-btn" %>
       </div>
       <%# /下部ボタン %>
-    <% end %> 
+    <% end %>
   </div>
 
   <footer class="items-sell-footer">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,145 +7,143 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, url: item_path, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+      <%= render 'shared/error_messages', model: @item %>
 
-    <%# 出品画像 %>
-    <div class="img-upload">
-      <div class="weight-bold-text">
-        出品画像
-        <span class="indispensable">必須</span>
-      </div>
-      <div class="click-upload">
-        <p>
-          クリックしてファイルをアップロード
-        </p>
-        <%= f.file_field :hoge, id:"item-image" %>
-      </div>
-    </div>
-    <%# /出品画像 %>
-    <%# 商品名と商品説明 %>
-    <div class="new-items">
-      <div class="weight-bold-text">
-        商品名
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
-      <div class="items-explain">
+      <%# 出品画像 %>
+      <div class="img-upload">
         <div class="weight-bold-text">
-          商品の説明
+          出品画像
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <div class="click-upload">
+          <p>
+            クリックしてファイルをアップロード
+          </p>
+          <%= f.file_field :image, id:"item-image" %>
+        </div>
       </div>
-    </div>
-    <%# /商品名と商品説明 %>
-
-    <%# 商品の詳細 %>
-    <div class="items-detail">
-      <div class="weight-bold-text">商品の詳細</div>
-      <div class="form">
+      <%# /出品画像 %>
+      <%# 商品名と商品説明 %>
+      <div class="new-items">
         <div class="weight-bold-text">
-          カテゴリー
+          商品名
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
-        <div class="weight-bold-text">
-          商品の状態
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
-      </div>
-    </div>
-    <%# /商品の詳細 %>
-
-    <%# 配送について %>
-    <div class="items-detail">
-      <div class="weight-bold-text question-text">
-        <span>配送について</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div class="form">
-        <div class="weight-bold-text">
-          配送料の負担
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-        <div class="weight-bold-text">
-          発送元の地域
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
-        <div class="weight-bold-text">
-          発送までの日数
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-      </div>
-    </div>
-    <%# /配送について %>
-
-    <%# 販売価格 %>
-    <div class="sell-price">
-      <div class="weight-bold-text question-text">
-        <span>販売価格<br>(¥300〜9,999,999)</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div>
-        <div class="price-content">
-          <div class="price-text">
-            <span>価格</span>
+        <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+        <div class="items-explain">
+          <div class="weight-bold-text">
+            商品の説明
             <span class="indispensable">必須</span>
           </div>
-          <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
-        </div>
-        <div class="price-content">
-          <span>販売手数料 (10%)</span>
-          <span>
-            <span id='add-tax-price'></span>円
-          </span>
-        </div>
-        <div class="price-content">
-          <span>販売利益</span>
-          <span>
-            <span id='profit'></span>円
-          </span>
+          <%= f.text_area :explanation, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
         </div>
       </div>
-    </div>
-    <%# /販売価格 %>
+      <%# /商品名と商品説明 %>
 
-    <%# 注意書き %>
-    <div class="caution">
-      <p class="sentence">
-        <a href="#">禁止されている出品、</a>
-        <a href="#">行為</a>
-        を必ずご確認ください。
-      </p>
-      <p class="sentence">
-        またブランド品でシリアルナンバー等がある場合はご記載ください。
-        <a href="#">偽ブランドの販売</a>
-        は犯罪であり処罰される可能性があります。
-      </p>
-      <p class="sentence">
-        また、出品をもちまして
-        <a href="#">加盟店規約</a>
-        に同意したことになります。
-      </p>
-    </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
-    <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
-    </div>
-    <%# /下部ボタン %>
+      <%# 商品の詳細 %>
+      <div class="items-detail">
+        <div class="weight-bold-text">商品の詳細</div>
+        <div class="form">
+          <div class="weight-bold-text">
+            カテゴリー
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+          <div class="weight-bold-text">
+            商品の状態
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+        </div>
+      </div>
+      <%# /商品の詳細 %>
+
+      <%# 配送について %>
+      <div class="items-detail">
+        <div class="weight-bold-text question-text">
+          <span>配送について</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div class="form">
+          <div class="weight-bold-text">
+            配送料の負担
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+          <div class="weight-bold-text">
+            発送元の地域
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+          <div class="weight-bold-text">
+            発送までの日数
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:days_until_shipping_id, DaysUntilShipping.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        </div>
+      </div>
+      <%# /配送について %>
+
+      <%# 販売価格 %>
+      <div class="sell-price">
+        <div class="weight-bold-text question-text">
+          <span>販売価格<br>(¥300〜9,999,999)</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div>
+          <div class="price-content">
+            <div class="price-text">
+              <span>価格</span>
+              <span class="indispensable">必須</span>
+            </div>
+            <span class="sell-yen">¥</span>
+            <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          </div>
+          <div class="price-content">
+            <span>販売手数料 (10%)</span>
+            <span>
+              <span id='add-tax-price'></span>円
+            </span>
+          </div>
+          <div class="price-content">
+            <span>販売利益</span>
+            <span>
+              <span id='profit'></span>円
+            </span>
+          </div>
+        </div>
+      </div>
+      <%# /販売価格 %>
+
+      <%# 注意書き %>
+      <div class="caution">
+        <p class="sentence">
+          <a href="#">禁止されている出品、</a>
+          <a href="#">行為</a>
+          を必ずご確認ください。
+        </p>
+        <p class="sentence">
+          またブランド品でシリアルナンバー等がある場合はご記載ください。
+          <a href="#">偽ブランドの販売</a>
+          は犯罪であり処罰される可能性があります。
+        </p>
+        <p class="sentence">
+          また、出品をもちまして
+          <a href="#">加盟店規約</a>
+          に同意したことになります。
+        </p>
+      </div>
+      <%# /注意書き %>
+      <%# 下部ボタン %>
+      <div class="sell-btn-contents">
+        <%= f.submit "変更する" ,class:"sell-btn" %>
+        <%=link_to 'もどる', root_path, class:"back-btn" %>
+      </div>
+      <%# /下部ボタン %>
+    <% end %> 
   </div>
-  <% end %>
 
   <footer class="items-sell-footer">
     <ul class="menu">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -5,7 +5,7 @@
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, url: items_path, local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
       <%= render 'shared/error_messages', model: @item %>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -5,138 +5,14 @@
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, local: true do |f| %>
+    <%= form_with model: @item, local: true do |form| %>
 
       <%= render 'shared/error_messages', model: @item %>
-
-      <%# 出品画像 %>
-      <div class="img-upload">
-        <div class="weight-bold-text">
-          出品画像
-          <span class="indispensable">必須</span>
-        </div>
-        <div class="click-upload">
-          <p>
-            クリックしてファイルをアップロード
-          </p>
-          <%= f.file_field :image, id:"item-image" %>
-        </div>
-      </div>
-      <%# /出品画像 %>
-      <%# 商品名と商品説明 %>
-      <div class="new-items">
-        <div class="weight-bold-text">
-          商品名
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
-        <div class="items-explain">
-          <div class="weight-bold-text">
-            商品の説明
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.text_area :explanation, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
-        </div>
-      </div>
-      <%# /商品名と商品説明 %>
-
-      <%# 商品の詳細 %>
-      <div class="items-detail">
-        <div class="weight-bold-text">商品の詳細</div>
-        <div class="form">
-          <div class="weight-bold-text">
-            カテゴリー
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
-          <div class="weight-bold-text">
-            商品の状態
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
-        </div>
-      </div>
-      <%# /商品の詳細 %>
-
-      <%# 配送について %>
-      <div class="items-detail">
-        <div class="weight-bold-text question-text">
-          <span>配送について</span>
-          <a class="question" href="#">?</a>
-        </div>
-        <div class="form">
-          <div class="weight-bold-text">
-            配送料の負担
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-          <div class="weight-bold-text">
-            発送元の地域
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
-          <div class="weight-bold-text">
-            発送までの日数
-            <span class="indispensable">必須</span>
-          </div>
-          <%= f.collection_select(:days_until_shipping_id, DaysUntilShipping.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-        </div>
-      </div>
-      <%# /配送について %>
-
-      <%# 販売価格 %>
-      <div class="sell-price">
-        <div class="weight-bold-text question-text">
-          <span>販売価格<br>(¥300〜9,999,999)</span>
-          <a class="question" href="#">?</a>
-        </div>
-        <div>
-          <div class="price-content">
-            <div class="price-text">
-              <span>価格</span>
-              <span class="indispensable">必須</span>
-            </div>
-            <span class="sell-yen">¥</span>
-            <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
-          </div>
-          <div class="price-content">
-            <span>販売手数料 (10%)</span>
-            <span>
-              <span id='add-tax-price'></span>円
-            </span>
-          </div>
-          <div class="price-content">
-            <span>販売利益</span>
-            <span>
-              <span id='profit'></span>円
-            </span>
-          </div>
-        </div>
-      </div>
-      <%# /販売価格 %>
-
-      <%# 注意書き %>
-      <div class="caution">
-        <p class="sentence">
-          <a href="#">禁止されている出品、</a>
-          <a href="#">行為</a>
-          を必ずご確認ください。
-        </p>
-        <p class="sentence">
-          またブランド品でシリアルナンバー等がある場合はご記載ください。
-          <a href="#">偽ブランドの販売</a>
-          は犯罪であり処罰される可能性があります。
-        </p>
-        <p class="sentence">
-          また、出品をもちまして
-          <a href="#">加盟店規約</a>
-          に同意したことになります。
-        </p>
-      </div>
-      <%# /注意書き %>
+      <%= render 'item_data', form: form %>
+      
       <%# 下部ボタン %>
       <div class="sell-btn-contents">
-        <%= f.submit "出品する" ,class:"sell-btn" %>
+        <%= form.submit "出品する" ,class:"sell-btn" %>
         <%=link_to 'もどる', root_path, class:"back-btn" %>
       </div>
       <%# /下部ボタン %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -7,141 +7,141 @@
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, url: items_path, local: true do |f| %>
 
-    <%= render 'shared/error_messages', model: @item %>
+      <%= render 'shared/error_messages', model: @item %>
 
-    <%# 出品画像 %>
-    <div class="img-upload">
-      <div class="weight-bold-text">
-        出品画像
-        <span class="indispensable">必須</span>
-      </div>
-      <div class="click-upload">
-        <p>
-          クリックしてファイルをアップロード
-        </p>
-        <%= f.file_field :image, id:"item-image" %>
-      </div>
-    </div>
-    <%# /出品画像 %>
-    <%# 商品名と商品説明 %>
-    <div class="new-items">
-      <div class="weight-bold-text">
-        商品名
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
-      <div class="items-explain">
+      <%# 出品画像 %>
+      <div class="img-upload">
         <div class="weight-bold-text">
-          商品の説明
+          出品画像
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :explanation, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <div class="click-upload">
+          <p>
+            クリックしてファイルをアップロード
+          </p>
+          <%= f.file_field :image, id:"item-image" %>
+        </div>
       </div>
-    </div>
-    <%# /商品名と商品説明 %>
-
-    <%# 商品の詳細 %>
-    <div class="items-detail">
-      <div class="weight-bold-text">商品の詳細</div>
-      <div class="form">
+      <%# /出品画像 %>
+      <%# 商品名と商品説明 %>
+      <div class="new-items">
         <div class="weight-bold-text">
-          カテゴリー
+          商品名
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
-        <div class="weight-bold-text">
-          商品の状態
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
-      </div>
-    </div>
-    <%# /商品の詳細 %>
-
-    <%# 配送について %>
-    <div class="items-detail">
-      <div class="weight-bold-text question-text">
-        <span>配送について</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div class="form">
-        <div class="weight-bold-text">
-          配送料の負担
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-        <div class="weight-bold-text">
-          発送元の地域
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
-        <div class="weight-bold-text">
-          発送までの日数
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:days_until_shipping_id, DaysUntilShipping.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-      </div>
-    </div>
-    <%# /配送について %>
-
-    <%# 販売価格 %>
-    <div class="sell-price">
-      <div class="weight-bold-text question-text">
-        <span>販売価格<br>(¥300〜9,999,999)</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div>
-        <div class="price-content">
-          <div class="price-text">
-            <span>価格</span>
+        <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+        <div class="items-explain">
+          <div class="weight-bold-text">
+            商品の説明
             <span class="indispensable">必須</span>
           </div>
-          <span class="sell-yen">¥</span>
-          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_area :explanation, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
         </div>
-        <div class="price-content">
-          <span>販売手数料 (10%)</span>
-          <span>
-            <span id='add-tax-price'></span>円
-          </span>
-        </div>
-        <div class="price-content">
-          <span>販売利益</span>
-          <span>
-            <span id='profit'></span>円
-        </div>
-        </span>
       </div>
-    </div>
-    <%# /販売価格 %>
+      <%# /商品名と商品説明 %>
 
-    <%# 注意書き %>
-    <div class="caution">
-      <p class="sentence">
-        <a href="#">禁止されている出品、</a>
-        <a href="#">行為</a>
-        を必ずご確認ください。
-      </p>
-      <p class="sentence">
-        またブランド品でシリアルナンバー等がある場合はご記載ください。
-        <a href="#">偽ブランドの販売</a>
-        は犯罪であり処罰される可能性があります。
-      </p>
-      <p class="sentence">
-        また、出品をもちまして
-        <a href="#">加盟店規約</a>
-        に同意したことになります。
-      </p>
-    </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
-    <div class="sell-btn-contents">
-      <%= f.submit "出品する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
-    </div>
-    <%# /下部ボタン %>
+      <%# 商品の詳細 %>
+      <div class="items-detail">
+        <div class="weight-bold-text">商品の詳細</div>
+        <div class="form">
+          <div class="weight-bold-text">
+            カテゴリー
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+          <div class="weight-bold-text">
+            商品の状態
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+        </div>
+      </div>
+      <%# /商品の詳細 %>
+
+      <%# 配送について %>
+      <div class="items-detail">
+        <div class="weight-bold-text question-text">
+          <span>配送について</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div class="form">
+          <div class="weight-bold-text">
+            配送料の負担
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+          <div class="weight-bold-text">
+            発送元の地域
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+          <div class="weight-bold-text">
+            発送までの日数
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:days_until_shipping_id, DaysUntilShipping.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        </div>
+      </div>
+      <%# /配送について %>
+
+      <%# 販売価格 %>
+      <div class="sell-price">
+        <div class="weight-bold-text question-text">
+          <span>販売価格<br>(¥300〜9,999,999)</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div>
+          <div class="price-content">
+            <div class="price-text">
+              <span>価格</span>
+              <span class="indispensable">必須</span>
+            </div>
+            <span class="sell-yen">¥</span>
+            <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          </div>
+          <div class="price-content">
+            <span>販売手数料 (10%)</span>
+            <span>
+              <span id='add-tax-price'></span>円
+            </span>
+          </div>
+          <div class="price-content">
+            <span>販売利益</span>
+            <span>
+              <span id='profit'></span>円
+            </span>
+          </div>
+        </div>
+      </div>
+      <%# /販売価格 %>
+
+      <%# 注意書き %>
+      <div class="caution">
+        <p class="sentence">
+          <a href="#">禁止されている出品、</a>
+          <a href="#">行為</a>
+          を必ずご確認ください。
+        </p>
+        <p class="sentence">
+          またブランド品でシリアルナンバー等がある場合はご記載ください。
+          <a href="#">偽ブランドの販売</a>
+          は犯罪であり処罰される可能性があります。
+        </p>
+        <p class="sentence">
+          また、出品をもちまして
+          <a href="#">加盟店規約</a>
+          に同意したことになります。
+        </p>
+      </div>
+      <%# /注意書き %>
+      <%# 下部ボタン %>
+      <div class="sell-btn-contents">
+        <%= f.submit "出品する" ,class:"sell-btn" %>
+        <%=link_to 'もどる', root_path, class:"back-btn" %>
+      </div>
+      <%# /下部ボタン %>
+    <% end %>
   </div>
-  <% end %>
 
   <footer class="items-sell-footer">
     <ul class="menu">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
 
     <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示 %>
     <% if user_signed_in? && current_user.id == @item.user_id %>
-      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <%# 商品が売れていない場合に表示 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
 
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
 
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit]
 end


### PR DESCRIPTION
## What
1. ルーティング、itemsコントローラーにedit, updateアクションを設定
2. 商品編集ページへのリンクを設置、編集ページの実装
3. 情報更新の成否による処理の分岐を設定
4. 編集、出品ページで重複する記述を部分テンプレートとして切り出し
5. 未ログイン、もしくは出品者ではないユーザーに対するリダイレクトを設定

## Why
1. 編集ページへの遷移、及びデータ更新を行えるようにするため
2. 商品情報を編集する機能を実装するため
3. 更新に成功、または失敗した際に正しい処理が行なわれるようにするため
4. コードの可読性を高めるため
5. 直接編集ページにくるのを防ぐため

### GIF画像
[商品情報を変更する](https://gyazo.com/399915cd96263e24ef00518afd6eb13b)
[編集せずに「変更する」ボタンを押しても画像なしにならない](https://gyazo.com/f242f54324704b068733f0e91b75c44a)
[未ログインユーザーは編集ページに遷移できない](https://gyazo.com/9c4edf3a61f823ad99022f5b7d78f1b9)
[出品者ではないユーザーは編集ページに遷移できない](https://gyazo.com/dd3c5f45843fefe838eed927d5f76059)