### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:destory]
+  before_action :set_item, only: [:destroy]
   def index
     @items = Item.all.order("created_at DESC")
     @purchases = Purchase.all
@@ -27,10 +27,13 @@ class ItemsController < ApplicationController
     @purchases = Purchase.all
   end
 
-  def destory
-    @item.destory
+  def destroy
+    if current_user.id == @item.user_id
+      @item.destroy
+      redirect_to root_path
+    end
   end
-  
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,9 +28,10 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if current_user.id == @item.user_id
-      @item.destroy
+    if current_user.id == @item.user_id && @item.destroy
       redirect_to root_path
+    else
+      render :show
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :set_item, only: [:destory]
   def index
     @items = Item.all.order("created_at DESC")
     @purchases = Purchase.all
@@ -26,9 +27,17 @@ class ItemsController < ApplicationController
     @purchases = Purchase.all
   end
 
+  def destory
+    @item.destory
+  end
+  
   private
 
   def item_params
     params.require(:item).permit(:image, :name, :explanation, :category_id, :condition_id, :shipping_charge_id, :prefecture_id, :days_until_shipping_id, :price).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
-      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <%= link_to '削除', item_path(@item), method: :delete, class:'item-destroy' %>
     <%# 商品が売れていない場合に表示 %>
     <% else %>
       <% unless @purchases.exists?(item_id: @item.id) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
 
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items
 end


### PR DESCRIPTION
## What
1. ルーティング、itemsコントローラーにdestroyアクションを設定
2. 「削除」ボタンを有効化、リダイレクトを設定

## Why
1. destroyアクションを定義するため
2. 商品データの削除をできるようにし、出品者以外のユーザーは削除できないようにするため

###GIF画像
[商品データの削除](https://gyazo.com/5692fece52cbe66faa5f8ba9a1299b6d)